### PR TITLE
Added support for grunt template stings.

### DIFF
--- a/tasks/s3.js
+++ b/tasks/s3.js
@@ -70,12 +70,22 @@ module.exports = function (grunt) {
 
   /**
    * Get the grunt s3 configuration options, filling in options from
-   * environment variables if present.
+   * environment variables if present. Also supports grunt template strings.
    *
    * @returns {Object} The s3 configuration.
    */
   function getConfig () {
-    return _.defaults(grunt.config('s3') || {}, {
+    var config = grunt.config('s3') || {};
+
+    // Look for and process grunt template stings
+    var keys = ['key', 'secret', 'bucket'];
+    keys.forEach(function(key) {
+      if (config.hasOwnProperty(key)) {
+        config[key] = grunt.template.process(config[key]);
+      }
+    });
+
+    return _.defaults(config, {
       key : process.env.AWS_ACCESS_KEY_ID,
       secret : process.env.AWS_SECRET_ACCESS_KEY
     });


### PR DESCRIPTION
Template strings in grunt will allow you to easily include values from other files. Below is an example of what im doing in my grunt.js file with this pull request to pull my aws settings from another file.

```
aws: '<json:grunt-aws.json>',
s3: {
    key: '<%= aws.key %>',
    secret: '<%= aws.secret %>',
    bucket: '<%= aws.bucket %>',
    access: 'public-read',
}
```

Where grunt-aws.json is just a json key:value file like package.json.
See https://github.com/cowboy/grunt/blob/master/docs/api_template.md
