### PR TITLE
Use the new "lowercase" version of underscore.deferred

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt": "~0.3.9",
     "async": "~0.1.18",
     "underscore": "~1.3.3",
-    "underscore.Deferred": "~0.1.3",
+    "underscore.deferred": "~0.1.4",
     "knox": "~0.0.9",
     "mime": "~1.2.5"
   },


### PR DESCRIPTION
When running `grunt s3` on a Linux machine using node `0.6.17`, require('underscore.deferred') blows up:

``` sh
Registering "grunt-s3" local Npm module tasks.
Loading "s3.js" tasks and helpers...ERROR
>> Error: Cannot find module 'underscore.deferred'
>>     at Function._resolveFilename (module.js:332:11)
>>     at Function._load (module.js:279:25)
>>     at Module.require (module.js:354:17)
>>     at require (module.js:370:17)
>>     at Object.<anonymous> (/home/user//scripts/node_modules/grunt-s3/tasks/s3.js:33:20)
```

This has something to do with the capitalization in package.json requiring 'underscore.Deferred' vs 'underscore.deferred.'

Using the new, strictly lowercase version of `underscore.deferred` (0.1.4) fixes this problem.
