### PR TITLE
Default headers overwrites after each task

### DIFF
--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -72,10 +72,10 @@ exports.init = function (grunt) {
       }
     });
 
-    return _.defaults(config, {
+    return common.clone(_.defaults(config, {
       key : process.env.AWS_ACCESS_KEY_ID,
       secret : process.env.AWS_SECRET_ACCESS_KEY
-    });
+    }));
   }
 
   /**


### PR DESCRIPTION
When default headers is set:

``` coffee-script
    s3:
      key: 'AWS KEY'
      secret: 'AWS SECRET'
      bucket: 'AWS BUCKET'
      access: 'public-read'
      headers:
        'Cache-Control': "public, max-age=#{60*60*24*cache_lifetime}"
      upload: [
        {
          src: '<%= dirs.dist %>js/*'
          dest: 'js/'
          gzip: true
        }
        {
          src: 'public/img/*'
          dest: 'img/'
        }
      ]
```

Each task in 'uploads' section overwrites global headers, because `getConfig` returns not a copy, but an original `headers` object. So, the following code changes global `headers` object, instead of just a local one:

``` java-script
    var config = _.defaults(options || {}, getConfig());
    var headers = options.headers || {};
```

``` java-script
      headers['Content-Encoding'] = 'gzip';
      headers['Content-Type'] = mime.lookup(src);

      var charset = mime.charsets.lookup(headers['Content-Type'], null);
      if (charset) {
        headers['Content-Type'] += '; charset=' + charset;
      }
```

So, all images will be uploaded to `img/` with wrong `Content-Encoding` and `Content-Type` headers.
