### PR TITLE
Grunt 0.4.0rc5 changes the grunt.file.expand API

### DIFF
--- a/tasks/s3.js
+++ b/tasks/s3.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
 
     config.upload.forEach(function(upload) {
       // Expand list of files to upload.
-      var files = grunt.file.expandFiles(upload.src),
+      var files = grunt.file.expand({ filter: "isFile" }, upload.src),
           destPath = grunt.template.process(upload.dest);
 
       files.forEach(function(file) {
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
         }
         else {
           if (upload.rel) {
-            dest = path.join(destPath, path.relative(grunt.file.expandDirs(upload.rel)[0], file));
+            dest = path.join(destPath, path.relative(grunt.file.expand({ filter: "isDirectory" }, upload.rel)[0], file));
           }
           else {
             dest = path.join(destPath, path.basename(file));


### PR DESCRIPTION
The commit gruntjs/grunt@b60907b7b07065a41325cd8a185d1a478b69f25a removed `grunt.file.expandFiles()` and `grunt.file.expandDirs()`. This PR addresses that change in `tasks/s3.js`.

These changes from grunt are not backwards compatible, and break the `s3` task completely.
