### PR TITLE
Refactor _ and async dependencies to come from grunt.util

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
   ],
   "dependencies": {
     "grunt": "0.4.x",
-    "async": "~0.1.18",
-    "underscore": "~1.3.3",
     "underscore.deferred": "~0.1.4",
     "knox": "0.4.1",
     "mime": "~1.2.5"

--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -14,10 +14,7 @@ const zlib = require('zlib');
 // Npm.
 const knox = require('knox');
 const mime = require('mime');
-const async = require('async');
-const _ = require('underscore');
 const deferred = require('underscore.deferred');
-_.mixin(deferred);
 
 // Local
 const common = require('./common');
@@ -46,6 +43,11 @@ const MSG_ERR_COPY = 'Copy error: %s to %s';
 const MSG_ERR_CHECKSUM = '%s error: expected hash: %s but found %s for %s';
 
 exports.init = function (grunt) {
+  var async = grunt.util.async,
+      _ = grunt.util._;
+
+  _.mixin(deferred);
+
   var exports = {};
 
   /**

--- a/tasks/s3.js
+++ b/tasks/s3.js
@@ -7,19 +7,19 @@
  *
  * Task: S3
  * Description: Move files to and from s3
- * Dependencies: knox, async, underscore.deferred
+ * Dependencies: knox, underscore.deferred
  *
  */
 
 module.exports = function (grunt) {
 
-  const _ = require('underscore');
   const path = require('path');
   const s3 = require('./lib/s3').init(grunt);
 
   /**
    * Grunt aliases.
    */
+  const _ = grunt.util._;
   const log = grunt.log;
 
   /**

--- a/test/upload.js
+++ b/test/upload.js
@@ -1,9 +1,10 @@
 
-var async = require('async');
 var grunt = require('grunt');
 var yaml = require('libyaml');
 var hashFile = require('../tasks/lib/common').hashFile;
 var s3 = require('../tasks/lib/s3').init(grunt);
+
+var async = grunt.util.async;
 
 module.exports = {
   testUpload : function (test) {


### PR DESCRIPTION
Grunt exposes underscore and async from the `grunt.util` namespace.  This change would remove your dependency on them.
