### PR TITLE
Added the 'secure' option for knox

### DIFF
--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -95,7 +95,7 @@ exports.init = function (grunt) {
 
     // Pick out the configuration options we need for the client.
     var client = knox.createClient(_(config).pick([
-      'endpoint', 'port', 'key', 'secret', 'access', 'bucket'
+      'endpoint', 'port', 'key', 'secret', 'access', 'bucket', 'secure'
     ]));
 
     if (config.debug) {


### PR DESCRIPTION
I added the secure option to the other knox options to allow for '.' in bucket names. Knox [issue #125](https://github.com/LearnBoost/knox/issues/125)
