### PR TITLE
deep-cloning `options.headers` fixes incorrect Content-Type for uploads

### DIFF
--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -139,7 +139,7 @@ exports.init = function (grunt) {
           });
         }
       });
-    }
+    };
 
     // If gzip is enabled, gzip the file into a temp file and then perform the
     // upload.


### PR DESCRIPTION
When uploading several files with different Content-Type headers, the Content-Type header of the last file to be uploaded is erroneously used for all files.

(to reproduce this, try defining a single task to upload various files of different types, such as .js and .css, and with the `gzip:true` option which will auto-detect the Content-Type header for each file)

This seems to be due to the fact that successive calls to `s3.upload` share the same `opts.headers` variable, which gets overwritten.
I found that deep-cloning the `opts` object fixes this behaviour.
