### PR TITLE
do not overwrite Content-Type Header when uploading gzip

### DIFF
--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -152,7 +152,7 @@ exports.init = function (grunt) {
     if (options.gzip && gzipExclude.indexOf(path.extname(src)) === -1) {
 
       headers['Content-Encoding'] = 'gzip';
-      headers['Content-Type'] = mime.lookup(src);
+      headers['Content-Type'] = headers['Content-Type'] || mime.lookup(src);
 
       var charset = mime.charsets.lookup(headers['Content-Type'], null);
       if (charset) {


### PR DESCRIPTION
Currently the grunt-s3-task is overwriting an existing 'Content-Type'-Header. This is kind of wrong, because you when you have overwritten it, you will check for the charset with the mime-module.

that only works for simple-text files. if i would like to upload 'application/javascript'-files, your default charset will be null. So i'm not able to upload gzipped js-files with UTF-8 charset.

i fixed that and only use the mime.lookup if the content-type-header is missing.

even if that issue wouldnt have arrised, i think it is not good to overwrite options which are settable from outside
