### PR TITLE
call res.resume() to prevent #95

### DIFF
--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -158,6 +158,7 @@ exports.init = function (grunt) {
             }
           });
         }
+        res.resume();
       });
     };
 


### PR DESCRIPTION
pifantastic/grunt-s3#95
