### PR TITLE
Create directories to file location on download

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "underscore.deferred": "~0.1.4",
     "knox": "0.8.x",
     "mime": "~1.2.5",
-    "temporary": "0.0.5"
+    "temporary": "0.0.5",
+    "mkdirp": "~0.3.5"
   },
   "devDependencies": {
     "nodeunit": "~0.7.4",

--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -16,6 +16,7 @@ var zlib = require('zlib');
 // Npm.
 var knox = require('knox');
 var mime = require('mime');
+var mkdirp = require('mkdirp');
 var deferred = require('underscore.deferred');
 var Tempfile = require('temporary/lib/file');
 
@@ -243,6 +244,9 @@ exports.init = function (grunt) {
     if (options.debug) {
       return dfd.resolve(util.format(MSG_DOWNLOAD_DEBUG, client.bucket, src, path.relative(process.cwd(), dest))).promise();
     }
+
+    // Recursively create directories to the file location, if they don't exist
+    mkdirp.sync(path.dirname(dest));
 
     // Create a local stream we can write the downloaded file to.
     var file = fs.createWriteStream(dest);


### PR DESCRIPTION
If I am downloading a file to `/my/file/location.txt` and its parent folders do not exist, the grunt task errors out. This fixes that issue and recursively creates the directories before opening a file stream.
