### PR TITLE
Fixed bug which broke headers

### DIFF
--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -110,7 +110,7 @@ exports.init = function (grunt) {
       return dfd.reject(makeError(MSG_ERR_NOT_FOUND, prettySrc));
     }
 
-    var headers = options.headers || {};
+    var headers = _.clone(options.headers || {});
 
     if (options.access) {
       headers['x-amz-acl'] = options.access;


### PR DESCRIPTION
When I uploaded multiple large files with option maxOperations=5 headers (especially Content-Type) messed up. This fix solved my problem.

Could be also relevant with issue https://github.com/pifantastic/grunt-s3/issues/100.
