### PR TITLE
Set maxOperations to a sensible default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A quick reference of options
 * **secret** - (*string*) An Amazon S3 credentials secret
 * **bucket** - (*string*) An Amazon S3 bucket
 * **region** - (*string*) An Amazon AWS region (see http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-* **maxOperations** - (*number*) max number of concurrent transfers - if not specified or set to 0, will be unlimited.
+* **maxOperations** - (*number*) max number of concurrent transfers - if set to 0, will be unlimited. Default: 20
 * **encodePaths** - (*boolean*) if set to true, will encode the uris of destinations to prevent 505 errors. Default: false
 * **headers** - (*object*) An object containing any headers you would like to send along with the
 transfers i.e. `{ 'X-Awesomeness': 'Out-Of-This-World', 'X-Stuff': 'And Things!' }`

--- a/tasks/lib/S3Task.js
+++ b/tasks/lib/S3Task.js
@@ -140,7 +140,7 @@ S3Task.prototype = {
       secret: process.env.AWS_SECRET_ACCESS_KEY,
       debug: false,
       verify: false,
-      maxOperations: 0,
+      maxOperations: 20,
       encodePaths: false,
       logSuccess: true,
       logErrors: true


### PR DESCRIPTION
There aren't many sensible reasons why you'd want `unlimited` as the default option here. Unlimited will cause more issues than not being unlimited. Ultimately I ended up increasing my local `ulimit` to get around the file descriptor issue with it trying to use unlimited resources before digging into the code and realized there was already a semaphore to limit the number of concurrent requests.

This library should provide a sane default, and if a user's use case demands them using more than 20 concurrent, they can easily increase.
