### PR TITLE
S3 download sometimes hashes before the file finishes writing.

### DIFF
--- a/tasks/lib/s3.js
+++ b/tasks/lib/s3.js
@@ -247,7 +247,7 @@ exports.init = function (grunt) {
     // Create a local stream we can write the downloaded file to.
     var file = fs.createWriteStream(dest);
 
-    // Upload the file to s3.
+    // Download the file from s3.
     client.getFile(src, function (err, res) {
       // If there was an upload error or any status other than a 200, we
       // can assume something went wrong.
@@ -255,38 +255,34 @@ exports.init = function (grunt) {
         return dfd.reject(makeError(MSG_ERR_DOWNLOAD, src, err || res.statusCode));
       }
 
+      var hash = crypto.createHash('md5');
       res
         .on('data', function (chunk) {
           file.write(chunk);
+          // Build the hash as it downloads.
+          hash.update(chunk);
         })
         .on('error', function (err) {
           return dfd.reject(makeError(MSG_ERR_DOWNLOAD, src, err));
         })
         .on('end', function () {
-          file.end(function() {
-              // Read the local file so we can get its md5 hash.
-              fs.readFile(dest, function (err, data) {
-                if (err) {
-                  return dfd.reject(makeError(MSG_ERR_DOWNLOAD, src, err));
-                }
-                else {
-                  // The etag head in the response from s3 has double quotes around
-                  // it. Strip them out.
-                  var remoteHash = res.headers.etag.replace(/"/g, '');
+            file.end();
 
-                  // Get an md5 of the local file so we can verify the download.
-                  var localHash = crypto.createHash('md5').update(data).digest('hex');
+            // The etag head in the response from s3 has double quotes around
+            // it. Strip them out.
+            var remoteHash = res.headers.etag.replace(/"/g, '');
 
-                  if (remoteHash === localHash) {
-                    var msg = util.format(MSG_DOWNLOAD_SUCCESS, src, localHash);
-                    dfd.resolve(msg);
-                  }
-                  else {
-                    dfd.reject(makeError(MSG_ERR_CHECKSUM, 'Download', localHash, remoteHash, src));
-                  }
-                }
-              });
-          });
+            // Get an md5 of the local file so we can verify the download.
+            var localHash = hash.digest('hex');
+
+            if (remoteHash === localHash) {
+                var msg = util.format(MSG_DOWNLOAD_SUCCESS, src, localHash);
+                dfd.resolve(msg);
+            }
+            else {
+                dfd.reject(makeError(MSG_ERR_CHECKSUM, 'Download', localHash, remoteHash, src));
+            }
+
         });
     });
 


### PR DESCRIPTION
I don't see any way to make an automated test proving this. I just have a set of files and when I run the grunt task to download them repeatedly they will occasionally fail claiming to have the wrong hash. It seems to just be a race condition where `fs.readFile` reads the file before the final chunk has been flushed to disk.
