### PR TITLE
Don't assume `upload.src` is a simple string.

### DIFF
--- a/tasks/lib/S3Task.js
+++ b/tasks/lib/S3Task.js
@@ -87,7 +87,13 @@ S3Task.prototype = {
 
     return _.map(files, function (file) {
       file = path.resolve(file);
-      upload.src = path.resolve(grunt.template.process(upload.src));
+
+      // We only want to try and resolve/template-process the original wildcard
+      // if it is actually a string. Otherwise, it's a more complex input that
+      // grunt.file.expand accepts, so leave it be.
+      if (typeof upload.src === 'string') {
+        upload.src = path.resolve(grunt.template.process(upload.src));
+      }
 
       // Put the key, secret and bucket information into the upload for knox.
       var fileConfig = _.extend({}, config, upload.options || {});


### PR DESCRIPTION
Setting `upload.src` to an array of globs (as per the [grunt.file.expand](http://gruntjs.com/api/grunt.file#grunt.file.expand) docs) causes an "Object has no method 'replace'" error.

This fixes a simple assumption that upload.src will simply be a string. After the fix, some complex globbing patterns I wrote now work fine, which makes grunt-s3 much more powerful.
